### PR TITLE
Updating the alpine image to include ca certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:3.7
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 COPY shepherd /shepherd
 ENTRYPOINT ["/shepherd"]


### PR DESCRIPTION
The included docker image doesn't work because CA Certificates hasn't been included, which fails calls made by go as it uses these root certs when making HTTPS calls.