### PR TITLE
Fix CLI flags for version, dryrun, debug and remove notifications from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ script:
   - make build
 #- make cover
 
+notifications:
+  email: false
+
 deploy:
   - provider: script
     skip_cleanup: true

--- a/main.go
+++ b/main.go
@@ -20,8 +20,7 @@ var (
 	maintainer string
 	pbranch    string
 
-	vrsn  bool
-	debug bool
+	vrsn bool
 )
 
 const (
@@ -53,7 +52,6 @@ func init() {
 	flag.BoolVar(&dryRun, "dryrun", false, "optional: do not change branch settings just print the changes that would occur")
 
 	flag.BoolVar(&vrsn, "version", false, "optional: print version and exit")
-	flag.BoolVar(&debug, "debug", false, "optional: run in debug mode")
 
 	// Exit safely when version is used
 	if vrsn {

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func init() {
 
 	// Exit safely when version is used
 	if vrsn {
-		fmt.Sprintf(BANNER, version)
+		fmt.Printf(BANNER, version)
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -45,14 +45,20 @@ developed with <3 by Sriram Venkatesh
 func init() {
 	// parse flags
 	flag.StringVar(&token, "token", os.Getenv("GITHUB_TOKEN"), "required: GitHub API token (or env var GITHUB_TOKEN)")
-	flag.StringVar(&baseURL, "url", "", "optional: GitHub Enterprise URL (default: github.com)")
+	flag.StringVar(&baseURL, "url", "", "optional: GitHub Enterprise URL")
 	flag.StringVar(&org, "org", "", "required: organization to look through")
 	flag.StringVar(&maintainer, "maintainer", "", "required: team to set as CODEOWNERS")
-	flag.StringVar(&pbranch, "branch", "master", "optional: branch to protect (default: master)")
-	flag.BoolVar(&dryRun, "dryrun", false, "optional: do not change branch settings just print the changes that would occur (default: false)")
+	flag.StringVar(&pbranch, "branch", "master", "optional: branch to protect")
+	flag.BoolVar(&dryRun, "dryrun", false, "optional: do not change branch settings just print the changes that would occur")
 
 	flag.BoolVar(&vrsn, "version", false, "optional: print version and exit")
 	flag.BoolVar(&debug, "debug", false, "optional: run in debug mode")
+
+	// Exit safely when version is used
+	if vrsn {
+		fmt.Sprintf(BANNER, version)
+		os.Exit(0)
+	}
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, fmt.Sprintf(BANNER, version))


### PR DESCRIPTION
This PR has a bunch of fixes for the CLI which are summarized below:

- version flag wouldn't noop and will return an exit code of 1 and return an error (GitHub token not provided)

- debug flag wasn't used anywhere, so I deleted it for now (will add it back later when I actually need it)

- dryRun wouldn't actually work as intended because it would have set branch protection and set repo management if the codeowners actually already existed

- disable notifications from travis (it spams a bit too much)